### PR TITLE
Fixed email header

### DIFF
--- a/source/GitPocket/GitPocket.Shared/Strings/en/Resources.resw
+++ b/source/GitPocket/GitPocket.Shared/Strings/en/Resources.resw
@@ -121,7 +121,7 @@
     <value>GitPocket</value>
   </data>
   <data name="LoginIn.Text" xml:space="preserve">
-    <value>Login In</value>
+    <value>Logging in</value>
   </data>
   <data name="PasswordHeader.Header" xml:space="preserve">
     <value>password</value>
@@ -139,6 +139,6 @@
     <value>Sign in with GitHub</value>
   </data>
   <data name="UserNameEmail.Header" xml:space="preserve">
-    <value>Username or Email</value>
+    <value>Email</value>
   </data>
 </root>

--- a/source/GitPocket/GitPocket.WindowsPhone/Views/MainPage.xaml
+++ b/source/GitPocket/GitPocket.WindowsPhone/Views/MainPage.xaml
@@ -79,7 +79,7 @@
                     Opacity="0">
             <TextBox TextWrapping="Wrap"
                      x:Uid="UserNameEmail"
-                     Header="Username or Email"
+                     Header="Email"
                      VerticalAlignment="Stretch"
                      BorderThickness="2.5"
                      Margin="0,5" />


### PR DESCRIPTION
In my last PR, I forgot to update the header so that it just says "Email". That has been fixed in this commit. 